### PR TITLE
chore(ci): use meza ubuntu slim runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Release:
-    runs-on: self-hosted
+    runs-on: meza-ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.3

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   verify:
     name: Verify PR
-    runs-on: self-hosted
+    runs-on: meza-ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.3


### PR DESCRIPTION
## Summary

Replace `runs-on: self-hosted` with `runs-on: meza-ubuntu-slim` in 2 GitHub Actions workflow files.

## Validation

- Verified 2 exact runner-label replacements.
- Verified no other staged lines changed.
- `git diff --check` passes.